### PR TITLE
Mods to use gunicorn and remove csrf exemption for upload

### DIFF
--- a/api/core/views.py
+++ b/api/core/views.py
@@ -17,7 +17,6 @@ from io import BytesIO
 from pathlib import Path
 from django.core.management import call_command
 
-@csrf_exempt
 def file_upload_view(request):
     if request.method == 'POST':
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 services:
   api:
-    build: .
-    command: python manage.py runserver ${HOST:-0.0.0.0}:8000
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: gunicorn --bind :8000 config.wsgi:application --workers 3 --timeout 120
     env_file:
       - .env
     environment:


### PR DESCRIPTION
* Modifies the command specified in docker-compose to use gunicorn instead of `python manage.py runserver`
* Removes csrf exemption on the upload endpoint