### PR TITLE
Fix cruise track

### DIFF
--- a/api/chl/api.py
+++ b/api/chl/api.py
@@ -3,6 +3,10 @@ from .services import ChlService
 
 router = Router()
 
+@router.get("/all", tags=["Users"])    # must be before get/cruise_name
+def getall(request):
+    return ChlService.getall()
+
 @router.get("/{cruise_name}", tags=["Users"])
 def get(request, cruise_name: str):
     return ChlService.get(cruise_name)

--- a/api/chl/management/commands/importchl.py
+++ b/api/chl/management/commands/importchl.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
 
             chl = chl.merge(btl_sum, on=['cruise','cast','niskin'], how='left')
             chl = chl.dropna(subset=['cruise'])
-            chl.sort_values('date')
+            chl = chl.sort_values('date')
             return chl
 
     def read_chl_data(self):

--- a/api/chl/services.py
+++ b/api/chl/services.py
@@ -1,61 +1,70 @@
 import io
 import os
-from datetime import datetime
+import csv
 from django.http import FileResponse, HttpResponse, Http404
 from storage.mediastore import MediaStore
 from storage.utils import PrefixStore
 from core.models import Cruise
-from django.conf import settings
-from pathlib import Path
 
 class ChlService:
+    URL = os.getenv("URL")
+    TOKEN = os.getenv("TOKEN")
+    MEDIASTORE_PREFIX = os.getenv("MEDIASTORE_PREFIX")
+    FILE_SUFFIX = '_chl.csv'
 
     @classmethod
     def get(cls, cruise_name: str) -> FileResponse:
-        URL = os.getenv("URL")
-        TOKEN = os.getenv("TOKEN")
-        MEDIASTORE_PREFIX = os.getenv("MEDIASTORE_PREFIX")
 
-        FILE_SUFFIX = '_chl.csv'
-        combined = bytearray()
-        first = True
+        try:
+            Cruise.objects.get(name__iexact=cruise_name) 
+            object_key = f"{cruise_name}{cls.FILE_SUFFIX}"
+            with MediaStore(cls.URL, token=cls.TOKEN) as store:
+                prefix = PrefixStore(store, cls.MEDIASTORE_PREFIX)
+                try:
+                    data = prefix.get(object_key)
+                except Exception as e:
+                    print(e, flush=True)
+                    raise
+            csv_buffer = io.BytesIO(data)
+            response = HttpResponse(csv_buffer, content_type='text/csv')
+            response['Content-Disposition'] = f'attachment; filename="{object_key}"'
+            return response
+        except Cruise.DoesNotExist:
+            raise Http404(f"Cruise {cruise_name} not found.")
 
-        if cruise_name.lower() == 'all':
-            parent_dir = Path('/vast/raw/')
-            cruises = [f.name for f in parent_dir.iterdir() if f.is_dir() and f.name != "all"]
-        else:
-            cruises = [cruise_name]
-      
-        for cruise_name in cruises:
-            try:
-                Cruise.objects.get(name__iexact=cruise_name)
-                object_key = f"{cruise_name}{FILE_SUFFIX}"
-                with MediaStore(URL, token=TOKEN) as store:
-                    prefix = PrefixStore(store, MEDIASTORE_PREFIX)
-                    try:
-                        data = prefix.get(object_key)
-                    except Exception as e:
-                        print(e, flush=True)
-                        raise
+    @classmethod
+    def getall(cls) -> FileResponse:
+        csv_buffer = io.StringIO()
+        csv_writer = csv.writer(csv_buffer)
 
-                    lines = data.decode('utf-8').splitlines(keepends=True)
-                    if not lines:
-                        continue
-                    if first:
-                        combined.extend("".join(lines).encode('utf-8'))
-                        first = False
-                    else:
-                        # Skip the header (line 0)
-                        combined.extend("".join(lines[1:]).encode('utf-8'))
-                        print(combined, flush=True)
-            except Cruise.DoesNotExist:
-                raise Http404(f"Cruise {cruise_name} not found.")
-            
-        csv_buffer = io.BytesIO(combined)
-        response = HttpResponse(csv_buffer, content_type='text/csv')
-        if len(cruises) > 1:
-            object_key = f"all{FILE_SUFFIX}"
-        response['Content-Disposition'] = f'attachment; filename="{object_key}"'
+        is_first_cruise = True
+        cruises = Cruise.objects.all().order_by('name')
+
+        for cruise in cruises:
+            object_key = f"{cruise.name}{cls.FILE_SUFFIX}"
+            with MediaStore(cls.URL, token=cls.TOKEN) as store:
+                prefix = PrefixStore(store, cls.MEDIASTORE_PREFIX)
+                try:
+                    data = prefix.get(object_key)
+                except Exception as e:
+                    continue
+
+            cruise_data = data.decode('utf-8')
+            reader = csv.reader(io.StringIO(cruise_data))
+
+            if is_first_cruise:
+                # first cruise: write everything including header
+                for row in reader:
+                    csv_writer.writerow(row)
+                is_first_cruise = False
+            else:
+                # other cruises: skip header
+                next(reader, None) 
+                for row in reader:
+                    csv_writer.writerow(row)
+
+        # Reset the pointer to the start
+        csv_buffer.seek(0)
+        response = HttpResponse(csv_buffer.getvalue(), content_type='text/csv')
+        response['Content-Disposition'] = f'attachment; filename="all_chl.csv"'
         return response
-    
-

--- a/api/core/templates/cruise_track.html
+++ b/api/core/templates/cruise_track.html
@@ -30,6 +30,13 @@
 </head>
 <body>
     <h1>Cruise Track for {{ cruise.name }}</h1>
+    {% if errors %}
+    <div style="background-color: #ffe0e0; padding: 6px 10px; border: 1px solid red; margin: 10px; font-size: 0.9em;">
+        <strong>Invalid Track Points:</strong>
+        {{ errors|join:", " }}
+    </div>
+    {% endif %}
+
     <div id="map"></div>
 
     <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>

--- a/api/core/templates/cruise_track.html
+++ b/api/core/templates/cruise_track.html
@@ -42,53 +42,52 @@
         // This incompatibility can prevent markers from displaying correctly on the map.
         // To address this issue, you might consider using the Leaflet.markercluster plugin as an alternative.
 
+        const castPoints = JSON.parse(`{{ cast_points_json|safe }}`);
+        const trackPoints = JSON.parse(`{{ track_points_json|safe }}`);
+
         const map = L.map('map').setView([0, 0], 2);
 
+        // Base layer
         L.tileLayer('https://services.arcgisonline.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}', {
             attribution: 'Tiles © Esri — Sources: GEBCO, NOAA, National Geographic, and others',
             maxZoom: 13
         }).addTo(map);
 
-        const trackPoints = JSON.parse(`{{ track_points_json|safe }}`);
+        // 1. Add clickable cast markers
+        const markers = L.markerClusterGroup();
 
+        castPoints.forEach(p => {
+            const marker = L.marker([p.lat, p.lng])
+                .bindTooltip("Cast " + p.label, {
+                    permanent: true,
+                    direction: 'top',
+                    offset: [0, -10]
+                })
+                .bindPopup(`
+            <strong>Cast ${p.label}</strong><br>
+            Latitude: ${p.lat.toFixed(5)}<br>
+            Longitude: ${p.lng.toFixed(5)}<br>
+            Depth: ${p.depth} m<br>
+            Start Time: ${p.start_time}<br>
+            <a href="/cruise/{{ cruise.name }}/cast/${p.label}/ctd_plot/" target="_blank">
+                View CTD Plot
+            </a>
+        `);
+            markers.addLayer(marker);
+        });
+        map.addLayer(markers);
+
+        // 2. Add polyline (cruise track)
         if (trackPoints.length > 0) {
             const latlngs = trackPoints.map(p => [p.lat, p.lng]);
 
-            const markers = L.markerClusterGroup();
+            L.polyline(latlngs, { color: 'blue' }).addTo(map);
 
-            trackPoints.forEach(p => {
-                const marker = L.marker([p.lat, p.lng])
-                    .bindTooltip("Cast " + p.label, {
-                        permanent: true,
-                        direction: 'top',
-                        offset: [0, -10]
-                    })
-                    .bindPopup(`
-                <strong>Cast ${p.label}</strong><br>
-                Latitude: ${p.lat.toFixed(5)}<br>
-                Longitude: ${p.lng.toFixed(5)}<br>
-                Depth: ${p.depth} m<br>
-                Start Time: ${p.start_time}<br>
-                <a href="/cruise/{{ cruise.name }}/cast/${p.label}/ctd_plot/" target="_blank">
-                    View CTD Plot
-                </a>
-            `);
-            markers.addLayer(marker);
-            });
-
-
-            map.addLayer(markers);
-
-            const polyline = L.polyline(latlngs, { color: 'blue' }).addTo(map);
-
-            //map.fitBounds(polyline.getBounds());
             const bounds = L.latLngBounds(latlngs);
-            map.fitBounds(bounds); // fits the entire track
+            map.fitBounds(bounds);
             setTimeout(() => {
-                const currentZoom = map.getZoom();
-                map.setZoom(currentZoom + 1);  // Zoom in to show clusters & single casts
-            }, 200); // 200ms delay is usually enough
-
+                map.setZoom(map.getZoom() + 1);
+            }, 200);
         } else {
             alert("No track data available.");
         }

--- a/api/core/templates/cruise_track.html
+++ b/api/core/templates/cruise_track.html
@@ -30,12 +30,6 @@
 </head>
 <body>
     <h1>Cruise Track for {{ cruise.name }}</h1>
-    {% if errors %}
-    <div style="background-color: #ffe0e0; padding: 6px 10px; border: 1px solid red; margin: 10px; font-size: 0.9em;">
-        <strong>Invalid Track Points:</strong>
-        {{ errors|join:", " }}
-    </div>
-    {% endif %}
 
     <div id="map"></div>
 

--- a/api/core/views.py
+++ b/api/core/views.py
@@ -170,7 +170,6 @@ def cruise_track_view(request, cruise_name):
                         for _, row in underway_data.iterrows()
                     ]
 
-        errors = []
         clean_track_points = []
         for i, point in enumerate(track_points):
             lat = clean_float(point["lat"])

--- a/api/core/views.py
+++ b/api/core/views.py
@@ -77,22 +77,25 @@ def file_upload_view(request):
 
         buffer = io.StringIO()
         command_lookup = {
-            'ctd': 'importcast',
-            'elog': 'importevent',
-            'underway': 'importunderwaydata',
-            'nutrient' : 'importnut',
-            'sample_log' : 'importnut',
-            'station_list' : 'importstations',
-            'hplc' : 'importhplc',
-            'chlorophyll' : 'importchl'
+            'ctd': ['importcast', 'importniskin'],
+            'elog': ['importevent'],
+            'underway': ['importunderwaydata'],
+            'nutrient' : ['importnut'],
+            'sample_log' : ['importnut'],
+            'station_list' : ['importstations'],
+            'hplc' : ['importhplc'],
+            'chlorophyll' : ['importchl']
         }
         message = f'Cruise name: {cruise_name},'
         message += f' File type: {file_type}.\n'
         try:
-            if file_type == 'station_list':
-                call_command(command_lookup.get(file_type), stdout=buffer)
-            else:
-                call_command(command_lookup.get(file_type), cruise_name=cruise_name, stdout=buffer)
+            commands = command_lookup.get(file_type, [])
+            for cmd in commands:
+                if file_type == 'station_list':
+                    call_command(cmd, stdout=buffer)
+                else:
+                    call_command(cmd, cruise_name=cruise_name, stdout=buffer)
+
             output = buffer.getvalue()
             buffer.close()
             import_message = output + '\nImport completed successfully.'

--- a/api/core/views.py
+++ b/api/core/views.py
@@ -104,12 +104,14 @@ def file_upload_view(request):
     return render(request, 'upload.html')
 
 def cruise_track_view(request, cruise_name):
+    UNDERWAY_SUFFIX = '_underway.csv'
+
     try:
         cruise = Cruise.objects.get(name__iexact=cruise_name)
         casts = Cast.objects.filter(cruise=cruise).order_by('start_time')
 
-        # Prepare track points for JS (GeoJSON-like)
-        track_points = [
+        # Prepare clickable cast points for JS (GeoJSON-like)
+        cast_points = [
             {
                 "lat": cast.geolocation.y,
                 "lng": cast.geolocation.x,
@@ -120,10 +122,51 @@ def cruise_track_view(request, cruise_name):
             for cast in casts
         ]
 
+        URL = os.getenv("URL")
+        TOKEN = os.getenv("TOKEN")
+        MEDIASTORE_PREFIX = os.getenv("MEDIASTORE_PREFIX")
+
+        object_key = f"{cruise_name}{UNDERWAY_SUFFIX}"
+        with MediaStore(URL, token=TOKEN) as store:
+            prefix = PrefixStore(store, MEDIASTORE_PREFIX)
+            try:
+                data = prefix.get(object_key)
+            except Exception as e:
+                print(e, flush=True)
+
+        underway_data = pd.read_csv(io.BytesIO(data))
+
+        # Non-clickable track points (no labels or popups)
+        try:
+            track_points = [
+                {"lat": row[" Dec_LAT"], "lng": row[" Dec_LON"]}
+                for _, row in underway_data.iterrows()
+            ]
+        except KeyError:
+            try:
+                track_points = [
+                    {"lat": row["Latitude_Deg"], "lng": row["Longitude_Deg"]}   # hrs2303
+                    for _, row in underway_data.iterrows()
+                ]
+            except KeyError:
+                try:
+                    track_points = [
+                        {"lat": row["GPS-Furuno-Latitude"], "lng": row["GPS-Furuno-Longitude"]}   # en
+                        for _, row in underway_data.iterrows()
+                    ]
+                except KeyError:
+                    track_points = [
+                        {"lat": row["Latitude"], "lng": row["Longitude"]}   # ae2426
+                        for _, row in underway_data.iterrows()
+                    ]
+        print(cast_points, flush=True)
+
         context = {
             'cruise': cruise,
             'track_points_json': json.dumps(track_points),
+            'cast_points_json': json.dumps(cast_points),
         }
+
         return render(request, 'cruise_track.html', context)
     except Cruise.DoesNotExist:
         raise CommandError(f'Cruise not found {cruise_name}. Run importcruise.py')

--- a/api/core/views.py
+++ b/api/core/views.py
@@ -180,7 +180,7 @@ def cruise_track_view(request, cruise_name):
                 lat < -90 or lat > 90 or
                 lng < -180 or lng > 180
             ):
-                errors.append(f"[Invalid] Entry {i}: lat={lat}, lng={lng}")
+                print(f"[Invalid] Entry {i}: lat={lat}, lng={lng}")
             else:
                 clean_track_points.append(point)
 
@@ -190,7 +190,6 @@ def cruise_track_view(request, cruise_name):
             'cruise': cruise,
             'track_points_json': json.dumps(track_points),
             'cast_points_json': json.dumps(cast_points),
-            'errors': errors,
         }
 
         return render(request, 'cruise_track.html', context)

--- a/api/core/views.py
+++ b/api/core/views.py
@@ -103,6 +103,12 @@ def file_upload_view(request):
 
     return render(request, 'upload.html')
 
+def clean_float(val):
+    try:
+        return float(str(val).strip().replace("–", "-"))
+    except Exception:
+        return None
+
 def cruise_track_view(request, cruise_name):
     UNDERWAY_SUFFIX = '_underway.csv'
 
@@ -155,16 +161,36 @@ def cruise_track_view(request, cruise_name):
                         for _, row in underway_data.iterrows()
                     ]
                 except KeyError:
+                    
                     track_points = [
                         {"lat": row["Latitude"], "lng": row["Longitude"]}   # ae2426
                         for _, row in underway_data.iterrows()
                     ]
-        print(cast_points, flush=True)
 
+        errors = []
+        clean_track_points = []
+        for i, point in enumerate(track_points):
+            lat = clean_float(point["lat"])
+            lng = clean_float(point["lng"])
+
+            if (
+                pd.isnull(lat) or pd.isnull(lng) or
+                not isinstance(lat, (float, int)) or
+                not isinstance(lng, (float, int)) or
+                lat < -90 or lat > 90 or
+                lng < -180 or lng > 180
+            ):
+                errors.append(f"[Invalid] Entry {i}: lat={lat}, lng={lng}")
+            else:
+                clean_track_points.append(point)
+
+        track_points = clean_track_points
+                    
         context = {
             'cruise': cruise,
             'track_points_json': json.dumps(track_points),
             'cast_points_json': json.dumps(cast_points),
+            'errors': errors,
         }
 
         return render(request, 'cruise_track.html', context)
@@ -211,7 +237,11 @@ def ctd_plot_view(request, cruise_name, cast_number):
     else:
         sensor_columns = en_primary_sensor_list
 
-    df = df.sort_values('date')
+    try:
+        df = df.sort_values('date')
+    except:
+        print(f'Cannot sort values by date for cruise {cruise_name}', flush=True)
+
     sensors = [col for col in sensor_columns if col in df.columns]
 
     # Create base figure

--- a/api/ctd/management/commands/importniskin.py
+++ b/api/ctd/management/commands/importniskin.py
@@ -4,6 +4,8 @@ import re
 import io
 import pandas as pd
 import numpy as np
+import sys
+from django.core.management.color import color_style
 from django.core.management.base import BaseCommand, CommandError
 from core.models import Cruise
 from core.models import Cast, Niskin
@@ -109,7 +111,13 @@ def to_dataframe(cruise_name, cast, in_lines):
         cvs[DATE_COL_IX] = '{} {}'.format(cvs[DATE_COL_IX], time)
         rows.append(cvs)
 
-    df = pd.DataFrame(rows, columns=col_headers)
+    try:
+        df = pd.DataFrame(rows, columns=col_headers)
+    except:
+        style = color_style()
+        sys.stdout.write(style.ERROR(f'Bad formatted .btl file columns found for cruise {cruise_name} cast {cast}.'))
+        return
+
     # convert df columns to reasonable types
     df[BOTTLE_COL] = df[BOTTLE_COL].astype(int)
     df[DATE_COL] = pd.to_datetime(df[DATE_COL], utc=True)
@@ -182,11 +190,14 @@ class Command(BaseCommand):
                             with open(file, 'r', encoding='latin1') as f:
                                 lines = f.readlines()                            
                             df = to_dataframe(cruise_name, cast, lines)
+                            if df is None:
+                                continue
                             
                             # add lat/lon and depth for armstrong and atlantis cruises
                             if LAT_COL not in df.columns and LON_COL not in df.columns:
                                 df[LAT_COL] = latitude
                                 df[LON_COL] = longitude
+                            
                             if DEPTH_COL not in df.columns and PRESSURE_COL in df.columns:
                                 df[DEPTH_COL] = [
                                     p_to_depth(float(p), float(lat)) if pd.notna(p) and pd.notna(lat) else None
@@ -200,12 +211,15 @@ class Command(BaseCommand):
                                     geolocation = Point(float(row[LON_COL]), float(row[LAT_COL]), srid=4326)
                                 else:
                                     geolocation = None
-                                if row[DEPTH_COL] is not None:
+                               
+                                if DEPTH_COL in row and row[DEPTH_COL] is not None:
                                     Niskin.objects.update_or_create(
                                         cast=cast_obj,
                                         number=row[NISKIN_COL],
-                                        depth= row[DEPTH_COL],  
-                                        geolocation = geolocation
+                                        defaults={
+                                            'depth': row[DEPTH_COL],
+                                            'geolocation': geolocation
+                                        }
                                     )
                                 else:
                                     self.stdout.write(self.style.ERROR(f'Depth for Cruise {cruise_name} cast {cast} niskin {row[NISKIN_COL]} null. Model not updated.'))
@@ -219,7 +233,6 @@ class Command(BaseCommand):
                             self.stdout.write(self.style.ERROR(f'Cast {cast} for Cruise {cruise_name} not imported. Run importcast.py'))
 
                 if glob.glob(os.path.join(directory, "*.btl")) and dfs:
-                    dfs = [df.dropna(subset=['depsm']) for df in dfs]
                     dfs = [df for df in dfs if not df.empty]  #remove empty dataframes
                     compiled_df = pd.concat(dfs, sort=False)
                     # 3 digit casts needed for sorting

--- a/api/events/management/commands/importevent.py
+++ b/api/events/management/commands/importevent.py
@@ -115,32 +115,11 @@ class Command(BaseCommand):
                    df[MESSAGE_ID] = range(1, len(df) + 1)   # assign message ids
                else:
                    directory = f'/vast/raw/{cruise_name}/elog/'
-                   file_pattern = os.path.join(directory, 'R2R_ELOG*FINAL*')
+                   file_pattern = os.path.join(directory, 'R2R_ELOG*FINAL*')  # do not read corrections or additions files in elog dir
                    matching_file = glob.glob(file_pattern)
                    if matching_file:
                        file_path = matching_file[0]
                        df = pd.read_csv(file_path, encoding='latin1',parse_dates=[DATETIME], dtype={'Station': str, 'Cast': str})
-                
-                       file_pattern = os.path.join(directory, 'R2R_ELOG*corrections.xlsx')
-                       matching_file = glob.glob(file_pattern)
-                       if matching_file:
-                           corr = self.apply_corrections(matching_file[0])
-                           merged = df.merge(corr, on=MESSAGE_ID, how='left')
-                           DATETIME_X = '{}_x'.format(DATETIME)
-                           DATETIME_Y = '{}_y'.format(DATETIME)
-                           merged[DATETIME] = pd.to_datetime(merged[DATETIME_Y].combine_first(merged[DATETIME_X]), utc=True)
-                           df = merged
-                
-                       file_pattern = os.path.join(directory, 'R2R_ELOG*additions.xlsx')
-                       matching_file = glob.glob(file_pattern)
-                       if matching_file:
-                           addns = self.apply_additions(matching_file[0])
-                           df = pd.concat([df, addns])
-                           max_message_id = int(df[MESSAGE_ID].max())
-                           new_ids = range(max_message_id + 1, max_message_id + 1 + df[MESSAGE_ID].isna().sum())
-                           df.loc[df[MESSAGE_ID].isna(), MESSAGE_ID] = new_ids
-                           df = df.reset_index(drop=True)
-                           df[MESSAGE_ID] = df[MESSAGE_ID].astype(pd.Int64Dtype())
 
                if not df.empty:
                    df['Comment'] = df['Comment'].fillna('')

--- a/api/nut/api.py
+++ b/api/nut/api.py
@@ -3,6 +3,10 @@ from .services import NutService
 
 router = Router()
 
+@router.get("/all", tags=["Users"])    # must be before get/cruise_name
+def getall(request):
+    return NutService.getall()
+
 @router.get("/{cruise_name}", tags=["Users"])
 def get(request, cruise_name: str):
     return NutService.get(cruise_name)

--- a/api/nut/management/commands/importnut.py
+++ b/api/nut/management/commands/importnut.py
@@ -61,8 +61,9 @@ class Command(BaseCommand):
         duplicate_ids = combined[combined.duplicated(keep=False)].unique()
         dup_rows = df[df['nut_a'].isin(duplicate_ids) | df['nut_b'].isin(duplicate_ids)]
         dup_rows = dup_rows[(dup_rows['nut_a'] != ' -') & (dup_rows['nut_b'] != ' -')]
-        print("Warning: Duplicate sample IDs found across nut_a and nut_b in LTER_sample_log.xlsx:")
-        print(dup_rows[['cruise', 'cast', 'niskin', 'nut_a', 'nut_b']].to_string())
+        if not dup_rows.empty:
+            print("Warning: Duplicate sample IDs found across nut_a and nut_b in LTER_sample_log.xlsx:")
+            print(dup_rows[['cruise', 'cast', 'niskin', 'nut_a', 'nut_b']].to_string())
 
         # make replicates long instead of wide
         sample_ids = wide_to_long(df, [['nut_a'],['nut_b']], ['sample_id'], 'replicate', ['a','b'])

--- a/api/nut/services.py
+++ b/api/nut/services.py
@@ -1,25 +1,25 @@
 import io
 import os
-from datetime import datetime
+import csv
 from django.http import FileResponse, HttpResponse, Http404
 from storage.mediastore import MediaStore
 from storage.utils import PrefixStore
 from core.models import Cruise
-from django.conf import settings
 
 class NutService:
+    URL = os.getenv("URL")
+    TOKEN = os.getenv("TOKEN")
+    MEDIASTORE_PREFIX = os.getenv("MEDIASTORE_PREFIX")
+    FILE_SUFFIX = '_nut.csv'
 
     @classmethod
     def get(cls, cruise_name: str) -> FileResponse:
-        URL = os.getenv("URL")
-        TOKEN = os.getenv("TOKEN")
-        MEDIASTORE_PREFIX = os.getenv("MEDIASTORE_PREFIX")
-        FILE_SUFFIX = '_nut.csv'
+
         try:
             Cruise.objects.get(name__iexact=cruise_name) 
-            object_key = f"{cruise_name}{FILE_SUFFIX}"
-            with MediaStore(URL, token=TOKEN) as store:
-                prefix = PrefixStore(store, MEDIASTORE_PREFIX)
+            object_key = f"{cruise_name}{cls.FILE_SUFFIX}"
+            with MediaStore(cls.URL, token=cls.TOKEN) as store:
+                prefix = PrefixStore(store, cls.MEDIASTORE_PREFIX)
                 try:
                     data = prefix.get(object_key)
                 except Exception as e:
@@ -31,4 +31,42 @@ class NutService:
             return response
         except Cruise.DoesNotExist:
             raise Http404(f"Cruise {cruise_name} not found.")    
+
+    @classmethod
+    def getall(cls) -> FileResponse:
+        csv_buffer = io.StringIO()
+        csv_writer = csv.writer(csv_buffer)
+
+        is_first_cruise = True
+        cruises = Cruise.objects.all().order_by('name')
+
+        for cruise in cruises:
+            object_key = f"{cruise.name}{cls.FILE_SUFFIX}"
+            with MediaStore(cls.URL, token=cls.TOKEN) as store:
+                prefix = PrefixStore(store, cls.MEDIASTORE_PREFIX)
+                try:
+                    data = prefix.get(object_key)
+                except Exception as e:
+                    continue
+
+            cruise_data = data.decode('utf-8')
+            reader = csv.reader(io.StringIO(cruise_data))
+
+            if is_first_cruise:
+                # first cruise: write everything including header
+                for row in reader:
+                    csv_writer.writerow(row)
+                is_first_cruise = False
+            else:
+                # other cruises: skip header
+                next(reader, None) 
+                for row in reader:
+                    csv_writer.writerow(row)
+
+        # Reset the pointer to the start
+        csv_buffer.seek(0)
+        response = HttpResponse(csv_buffer.getvalue(), content_type='text/csv')
+        response['Content-Disposition'] = f'attachment; filename="all_nut.csv"'
+        return response
+
 


### PR DESCRIPTION
Fixes issue #4 

To test: https://{host}/cruise/ar77/track/

or with any cruise name replacing ar77.

Fixes importniskin for ar24a. Removes code from importevent to read corrections and addition files in /elogs dir.

Also, run `importniskin --cruise_name ar24a` and `importevent` on all cruises.

Fixes chl sorting. Run `importchl `on all cruises