### PR TITLE
Clean column names for underway data

### DIFF
--- a/api/core/views.py
+++ b/api/core/views.py
@@ -153,25 +153,25 @@ def cruise_track_view(request, cruise_name):
         # Non-clickable track points (no labels or popups)
         try:
             track_points = [
-                {"lat": row[" Dec_LAT"], "lng": row[" Dec_LON"]}
+                {"lat": row["dec_lat"], "lng": row["dec_lon"]}   # ar
                 for _, row in underway_data.iterrows()
             ]
         except KeyError:
             try:
                 track_points = [
-                    {"lat": row["Latitude_Deg"], "lng": row["Longitude_Deg"]}   # hrs2303
+                    {"lat": row["latitude_deg"], "lng": row["longitude_deg"]}   # hrs2303
                     for _, row in underway_data.iterrows()
                 ]
             except KeyError:
                 try:
                     track_points = [
-                        {"lat": row["GPS-Furuno-Latitude"], "lng": row["GPS-Furuno-Longitude"]}   # en
+                        {"lat": row["gps_furuno_latitude"], "lng": row["gps_furuno_longitude"]}   # en
                         for _, row in underway_data.iterrows()
                     ]
                 except KeyError:
                     
                     track_points = [
-                        {"lat": row["Latitude"], "lng": row["Longitude"]}   # ae2426
+                        {"lat": row["latitude"], "lng": row["longitude"]}   # ae2426
                         for _, row in underway_data.iterrows()
                     ]
 

--- a/api/underway/management/commands/importunderwaydata.py
+++ b/api/underway/management/commands/importunderwaydata.py
@@ -6,6 +6,7 @@ from io import BytesIO, StringIO
 import pandas as pd
 from core.models import Cruise
 from core.models import Underway
+from core.utils import clean_column_names
 from storage.fs import FilesystemStore
 from storage.mediastore import MediaStore
 from storage.utils import PrefixStore
@@ -87,6 +88,9 @@ class Command(BaseCommand):
                     else:
                         start_datetime = pd.to_datetime(combined_data[date_column].iloc[0])
                         end_datetime = pd.to_datetime(combined_data[date_column].iloc[-1])
+
+                    df_data = clean_column_names(combined_data)
+
                 else:
                     raise ValueError(f"Unsupported cruise type for cruise_name: {cruise_name}")
                 start_datetime = None if pd.isna(start_datetime) else self.make_aware_if_naive(start_datetime)
@@ -100,7 +104,7 @@ class Command(BaseCommand):
                         )       
                 
                 csv_buffer = StringIO()
-                combined_data.to_csv(csv_buffer, index=False)
+                df_data.to_csv(csv_buffer, index=False)
                 csv_binary = csv_buffer.getvalue().encode('utf-8')
                 # Use the put method to store the CSV in the vast media store
                 object_key = f"{cruise_name}{self.FILE_SUFFIX}"


### PR DESCRIPTION
Fixed dashes in underway data column names by adding call to clean_column_names.

Run to fix all column names in the underway data files in the media store: 
`docker exec -it nes-lter-api-2-api-1 python manage.py importunderwaydata`